### PR TITLE
fix #91 restrict numpy version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,15 @@
 [project]
 name = "astroCAST"
 description = "package to analyze calcium flourescence events in astrocytes"
-version = "0.2.1.1"
+version = "0.2.1.2"
 author = ["Jan Philipp Reising", "Ana Cristina González"]
 author_email = "jan.reising@ki.se"
 dependencies = ["awkward", "colorcet", "opencv-python", "czifile", "dask", "dask-image", "datashader", "dtaidistance",
-                "fastcluster", "h5py", "hdbscan", "keras", "matplotlib", "multiprocess", "networkx", "pandas", "napari[all]", "napari-plot",
-                "powerlaw", "pynwb", "deprecated", "deprecation", "jupyterlab", "peakutils", "holoviews", "pointpats", "psutil", "ipyparallel", "pytest", "scipy", "seaborn", "scikit-image", "scikit-learn",
-                "tensorflow", "tifffile", "tiledb", "tqdm", "tsfresh", "tslearn", "umap-learn", "xarray", "xxhash", "jnormcorre", "numpy"]
+    "fastcluster", "h5py", "hdbscan", "keras", "matplotlib", "multiprocess", "networkx", "pandas",
+    "napari[all]", "napari-plot", "powerlaw", "pynwb", "deprecated", "deprecation", "jupyterlab",
+    "peakutils", "holoviews", "pointpats", "psutil", "ipyparallel", "pytest", "scipy", "seaborn",
+    "scikit-image", "scikit-learn", "tensorflow", "tifffile", "tiledb", "tqdm", "tsfresh", "tslearn",
+    "umap-learn", "xarray", "xxhash", "jnormcorre", "numpy<1.24"]
 
 [build-system]
 requires = ["hatchling"]


### PR DESCRIPTION
fix: due to a change in numpy>=2.4 ´np.int´ is deprecated but still used by the jnormcorre package. Requirement will hopefully lifted in future releases.