### PR TITLE
Remove napari dependencies from docker image creation

### DIFF
--- a/astroContainer/Dockerfile
+++ b/astroContainer/Dockerfile
@@ -12,7 +12,7 @@ RUN mkdir /home/data
 RUN cd /home && git clone https://github.com/janreising/astroCAST.git
 
 # Install astroCAST and jupyerlab
-RUN pip3 install astrocast[all]
+RUN pip3 install astrocast[testing,documentation]
 
 # Run command
 CMD [ "/bin/bash" ]


### PR DESCRIPTION
Currently it seems impossible to run napari from within the docker container, additionally installing the related packages seems to create problems with the container itself. Therefore 'video-player' is removed from the poetry extras during installation  